### PR TITLE
Proper documentation for 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ React native wrapper for Jitsi Meet SDK
 
 `npm install react-native-jitsi-meet --save` 
 
+If you are using React-Native < 0.60, you should use a version < 2.0.0.  
 For versions higher than 2.0.0, you need to add the following piece of code in your ```metro.config.js``` file to avoid conflicts between react-native-jitsi-meet and react-native in metro bundler.
 
 ```
@@ -18,8 +19,6 @@ module.exports = {
   },
 };
 ```
-
-For iOS, you'll need to modify your Podfile to have ```platform :ios, '10.0'``` and execute ```pod install```
 
 ## Use (>= 2.0.0)
 
@@ -123,7 +122,11 @@ You can add listeners for the following events:
 ```
 contains `<string>voip</string>`
 
-## iOS Manual Install (deprecated for RN >= 0.60)
+## iOS Manual Install for RN >= 0.60
+1.) Modify your Podfile to have ```platform :ios, '10.0'``` and execute ```pod install```  
+2.) In Xcode, under Build setting set Enable Bitcode to No  
+
+## iOS Manual Install for RN < 0.60
 ### Step 1. Add Files Into Project
 - 1-1.) in Xcode: Right click `Libraries` ➜ `Add Files to [project]`  
 - 1-2.) choose `node_modules/react-native-jitsi-meet/ios/RNJitsiMeet.xcodeproj` then `Add`  
@@ -225,7 +228,52 @@ done
 ```
 This will run a script everytime you build to clean the unwanted architecture
 
-## Android Manual Install (deprecated for RN >= 0.60)
+## Android Manual Install
+1.) In `android/app/build.gradle`, add/replace the following lines:
+
+```
+project.ext.react = [
+    entryFile: "index.js",
+    bundleAssetName: "app.bundle",
+]
+```
+
+2.) In `android/app/src/main/java/com/xxx/MainApplication.java` add/replace the following methods:
+
+```
+    @Override
+    protected String getJSMainModuleName() {
+      return "index";
+    }
+
+    @Override
+    protected @Nullable String getBundleAssetName() {
+      return "app.bundle";
+    }
+```
+
+3.) In `android/build.gradle`, add the following code 
+```
+allprojects {
+    repositories {
+        mavenLocal()
+        jcenter()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            url "https://maven.google.com"
+        }
+        maven { // <---- Add this block
+            url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+        }
+        maven { url "https://jitpack.io" }
+    }
+}
+```
+
+## Android Additional Manual Install for RN < 0.60
 
 1.) In `android/app/src/main/AndroidManifest.xml` add these permissions
 
@@ -280,38 +328,10 @@ dependencies {
     implementation(project(':react-native-jitsi-meet'))
 }
 ```
-and add/replace the following lines:
 
-```
-project.ext.react = [
-    entryFile: "index.js",
-    bundleAssetName: "app.bundle",
-]
-```
-
-5.) In `android/build.gradle`, add the following code 
-```
-allprojects {
-    repositories {
-        mavenLocal()
-        jcenter()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
-        }
-        maven {
-            url "https://maven.google.com"
-        }
-        maven { // <---- Add this block
-            url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
-        }
-        maven { url "https://jitpack.io" }
-    }
-}
-```
 and set your minSdkVersion to be at least 21.
 
-6.) In `android/app/src/main/java/com/xxx/MainApplication.java`
+5.) In `android/app/src/main/java/com/xxx/MainApplication.java`
 
 ```java
 import com.reactnativejitsimeet.JitsiMeetPackage;  // <--- Add this line
@@ -326,23 +346,10 @@ import android.support.annotation.Nullable; // <--- Add this line if not already
     }
 ```
 
-7.) In `android/app/src/main/java/com/xxx/MainApplication.java` add/replace the following methods:
-
-```
-    @Override
-    protected String getJSMainModuleName() {
-      return "index";
-    }
-
-    @Override
-    protected @Nullable String getBundleAssetName() {
-      return "app.bundle";
-    }
-```
 
 ### Side-note
 
-If your app already includes `react-native-locale-detector` or `react-native-vector-icons`, you must exclude them from the `react-native-jitsi-meet` project implementation with the following code:
+If your app already includes `react-native-locale-detector` or `react-native-vector-icons`, you must exclude them from the `react-native-jitsi-meet` project implementation with the following code (even if you're app uses autolinking with RN > 0.60):
 
 ```
     implementation(project(':react-native-jitsi-meet')) {


### PR DESCRIPTION
I added the necessary changes to make 2.0.0 work properly.
There is still one thing that could be added, but it is general to any version. It's about android SDK. In my experience when we want to use an older version of react-native-jitsi-meet and so an older version of the Jitsi meet SDK, then we have to use an older version of Jitsi-maven-repository. To do so we have to fork their repository and go back in time to a commit that fits our SDK version.
I don't know if I am the only one experiencing that as I didn't saw anyone complain about it in the issues, but maybe it could be helpful.
if people let me know that it would be useful to add that, I'll do so.