### PR TITLE
update jitsi-meet ios sdk version 3.7.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,47 +28,38 @@ Although most of the process is automated, you still have to follow the platform
 The following component is an example of use:
 
 ```
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View } from 'react-native';
 import JitsiMeet, { JitsiMeetView } from 'react-native-jitsi-meet';
 
-class VideoCall extends React.Component {
-  constructor(props) {
-    super(props);
-    this.onConferenceTerminated = this.onConferenceTerminated.bind(this);
-    this.onConferenceJoined = this.onConferenceJoined.bind(this);
-    this.onConferenceWillJoin = this.onConferenceWillJoin.bind(this);
+const VideoCall = () => {
+  const onConferenceTerminated = (nativeEvent) => {
+    /* Conference terminated event */
   }
 
-  componentDidMount() {
+  const onConferenceJoined = (nativeEvent) => {
+    /* Conference joined event */
+  }
+
+  const onConferenceWillJoin= (nativeEvent) => {
+    /* Conference will join event */
+  }
+
+  useEffect(() => {
     setTimeout(() => {
-      const url = 'https://your.jitsi.server/roomName'; // can also be only room name and will connect to jitsi meet servers
+      const url = 'https://meet.jit.si/deneme'; // can also be only room name and will connect to jitsi meet servers
       const userInfo = { displayName: 'User', email: 'user@example.com', avatar: 'https:/gravatar.com/avatar/abc123' };
       JitsiMeet.call(url, userInfo);
       /* You can also use JitsiMeet.audioCall(url) for audio only call */
       /* You can programmatically end the call with JitsiMeet.endCall() */
     }, 1000);
-  }
+  }, [])
 
-  onConferenceTerminated(nativeEvent) {
-    /* Conference terminated event */
-  }
-
-  onConferenceJoined(nativeEvent) {
-    /* Conference joined event */
-  }
-
-  onConferenceWillJoin(nativeEvent) {
-    /* Conference will join event */
-  }
-
-  render() {
-    return (
-      <View style={{ backgroundColor: 'black',flex: 1 }}>
-        <JitsiMeetView onConferenceTerminated={this.onConferenceTerminated} onConferenceJoined={this.onConferenceJoined} onConferenceWillJoin={this.onConferenceWillJoin} style={{ flex: 1, height: '100%', width: '100%' }} />
-      </View>
-    );
-  }
+  return (
+    <View style={{ backgroundColor: 'black', flex: 1 }}>
+      <JitsiMeetView onConferenceTerminated={onConferenceTerminated} onConferenceJoined={onConferenceJoined} onConferenceWillJoin={onConferenceWillJoin} style={{ flex: 1, height: '100%', width: '100%' }} />
+    </View>
+  )
 }
 
 export default VideoCall;

--- a/ios/RNJitsiMeetView.h
+++ b/ios/RNJitsiMeetView.h
@@ -1,6 +1,6 @@
-#import <JitsiMeet/JitsiMeet.h>
-
 #import <React/RCTComponent.h>
+
+@import JitsiMeetSDK;
 
 @interface RNJitsiMeetView : JitsiMeetView
 @property (nonatomic, copy) RCTBubblingEventBlock onConferenceJoined;

--- a/ios/RNJitsiMeetViewManager.h
+++ b/ios/RNJitsiMeetViewManager.h
@@ -1,5 +1,5 @@
 #import <React/RCTViewManager.h>
-#import <JitsiMeet/JitsiMeetViewDelegate.h>
+@import JitsiMeetSDK;
 
 @interface RNJitsiMeetViewManager : RCTViewManager <JitsiMeetViewDelegate>
 @end

--- a/ios/RNJitsiMeetViewManager.m
+++ b/ios/RNJitsiMeetViewManager.m
@@ -1,6 +1,6 @@
 #import "RNJitsiMeetViewManager.h"
 #import "RNJitsiMeetView.h"
-#import <JitsiMeet/JitsiMeetUserInfo.h>
+#import <JitsiMeetSDK/JitsiMeetUserInfo.h>
 
 @implementation RNJitsiMeetViewManager{
     RNJitsiMeetView *jitsiMeetView;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-jitsi-meet",
   "description": "Jitsi Meet SDK wrapper for React Native.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Sébastien Krafft",
     "email": "skrafft@gmail.com"

--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "11.0"
 
   s.source       = { :git => "https://github.com/skrafft/react-native-jitsi-meet.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '2.6.0'
+  s.dependency 'JitsiMeetSDK', '3.7.0'
 end


### PR DESCRIPTION
This pr upgrades IOS native SDK to 3.7.0 and example app function component update.