### PR TITLE
JCenter Shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are using React-Native < 0.60, you should use a version < 2.0.0.
 For versions higher than 2.0.0, you need to add the following piece of code in your ```metro.config.js``` file to avoid conflicts between react-native-jitsi-meet and react-native in metro bundler.
 
 ```
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 
 module.exports = {
   resolver: {

--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ project.ext.react = [
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -41,7 +41,6 @@ repositories {
   }
   google()
   mavenCentral()
-  jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
jcenter deprecated ,Please refer https://blog.gradle.org/jcenter-shutdown